### PR TITLE
fix(seo): added JSON-LD to index page

### DIFF
--- a/_includes/head.pug
+++ b/_includes/head.pug
@@ -39,4 +39,4 @@ head
   | {% include twitter_cards.html %}
 
   // Schema.org
-  | {% include script-index.html %}
+  | {% include schema-index.html %}

--- a/_includes/head.pug
+++ b/_includes/head.pug
@@ -39,4 +39,6 @@ head
   | {% include twitter_cards.html %}
 
   // Schema.org
+  | {% if page.url == "/" %}
   | {% include schema-index.html %}
+  | {% endif %}

--- a/_includes/head.pug
+++ b/_includes/head.pug
@@ -37,3 +37,6 @@ head
 
   // Twitter cards
   | {% include twitter_cards.html %}
+
+  // Schema.org
+  | {% include script-index.html %}

--- a/_includes/schema-index.html
+++ b/_includes/schema-index.html
@@ -1,0 +1,197 @@
+<!-- Schema Start-->
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "ActivityWatch",
+        "url": "https://activitywatch.net/",
+        "description": "The best free and open-source automated time tracker: cross-platform, extensible, and privacy-focused. Ideal for freelancers and designed with ADHD users in mind.",
+        "disambiguatingDescription": "This app is designed for personal task and time management. It helps users efficiently organize their tasks and manage their time effectively. With features tailored to enhance productivity and streamline workflow, it ensures that users can stay on top of their schedules and prioritize their responsibilities with ease.",
+        "keywords": ["time management", "task management", "software", "free auto time tracker", "free freelancer time tracking software"],
+        "abstract": "A collection of trackers that monitor and log key activities on your computer, such as detecting if you are AFK or identifying the active window. A system for storing the data collected by these trackers. A flexible data format that meets most logging requirements. An ecosystem of tools that allows users to customize and extend the software to suit their needs.",
+        "alternativeHeadline": "A free automated time tracker designed to monitor your activity and screen time. This tool helps you keep an accurate record of how you spend your time on your computer, providing insights into your productivity and screen usage patterns. It's an essential tool for improving time management and boosting efficiency.",
+        "about": "ActivityWatch is a bundle of software that tracks your computer activity. You are, by default, the sole owner of your data. It also offers an ecosystem of software to work around it, including ways to collect more data and do different kinds of analysis. We created ActivityWatch completely free and open source so anyone can use, improve and extend it.",
+        "applicationCategory": "https://en.wikipedia.org/wiki/Time-tracking_software",
+        "applicationSubCategory": ["DesktopApplication", "MobileApplication", "WebApplication"],
+        "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "4.2",
+            "reviewCount": "156"
+        },
+        "softwareVersion": "0.13.1",
+        "datePublished": "2024-06-12",
+        "dateCreated": "2016-06-10",
+        "downloadUrl": "https://activitywatch.net/downloads/",
+        "softwareHelp": "https://docs.activitywatch.net/en/latest/getting-started.html#installation",
+        "screenshot": "https://activitywatch.net/img/screenshots/screenshot-v0.9.3-activity.png",
+        "inLanguage": "en",
+        "featureList": [
+            "Application and window tracking",
+            "Usage categories",
+            "Browser extensions",
+            "Editor plugins (IDE)",
+            "Local and privacy first",
+            "Cross-platform",
+            "Synchronization"
+        ],
+        "audience": {
+            "@type": "Audience",
+            "audienceType": ["Business Professionals", "Freelancers", "Small Business", "ADHD individuals"]
+        },
+        "typicalAgeRange": "all ages",
+        "operatingSystem": ["Windows", "macOS", "Linux", "Android"],
+        "availableOnDevice": ["Desktop", "Mobile", "Tablet"],
+        "potentialAction": {
+            "@type": "ViewAction",
+            "target": [
+              "https://activitywatch.net/downloads/",
+              "android-app:https://play.google.com/store/apps/details?id=net.activitywatch.android",
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-windows-x86_64-setup.exe",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-windows-setup",
+                  "name": "ActivityWatch Windows Setup",
+                  "operatingSystem": "Windows"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-windows-x86_64.zip",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-windows-zip",
+                  "name": "ActivityWatch Windows Zip",
+                  "operatingSystem": "Windows"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://chocolatey.org/packages/activitywatch",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-chocolatey",
+                  "name": "ActivityWatch Chocolatey",
+                  "operatingSystem": "Windows"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-macos-x86_64.dmg",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-macos-dmg",
+                  "name": "ActivityWatch macOS DMG",
+                  "operatingSystem": "macOS"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-macos-x86_64.zip",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-macos-zip",
+                  "name": "ActivityWatch macOS Zip",
+                  "operatingSystem": "macOS"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://formulae.brew.sh/cask/activitywatch",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-homebrew",
+                  "name": "ActivityWatch Homebrew",
+                  "operatingSystem": "macOS"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-linux-x86_64.zip",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-linux-zip",
+                  "name": "ActivityWatch Linux Zip",
+                  "operatingSystem": "Linux"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-linux-x86_64.AppImage",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-linux-appimage",
+                  "name": "ActivityWatch Linux AppImage",
+                  "operatingSystem": "Linux"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://aur.archlinux.org/packages/activitywatch-bin/",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-arch-linux",
+                  "name": "ActivityWatch Arch Linux",
+                  "operatingSystem": "Linux"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://search.nixos.org/packages?query=activitywatch&show=activitywatch",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-nixos",
+                  "name": "ActivityWatch NixOS",
+                  "operatingSystem": "Linux"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://chrome.google.com/webstore/detail/nglaklhklhcoonedhgnpgddginnjdadi/",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-chrome",
+                  "name": "ActivityWatch Chrome Extension",
+                  "operatingSystem": "Chrome"
+                }
+              },
+              {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://addons.mozilla.org/en-US/firefox/addon/aw-watcher-web/",
+                "actionApplication": {
+                  "@type": "SoftwareApplication",
+                  "@id": "activitywatch-firefox",
+                  "name": "ActivityWatch Firefox Extension",
+                  "operatingSystem": "Firefox"
+                }
+              }
+            ]
+          },
+        "softwareRequirements": "Requires Windows 10 or later, macOS 10.15 or later, Linux kernel 5.4 or later, or Android 7.0 or later",
+        "creator": {
+            "@type": "Person",
+            "name": "Erik Bjäreholt",
+            "url": "https://erik.bjareholt.com/",
+            "sameAs": "https://www.linkedin.com/in/erikbjareholt/"
+        },
+        "maintainer": [
+            {
+                "@type": "Person",
+                "name": "Erik Bjäreholt",
+                "url": "https://erik.bjareholt.com/",
+                "sameAs": "https://www.linkedin.com/in/erikbjareholt/"
+            },
+            {
+                "@type": "Person",
+                "name": "Johan Bjäreholt",
+                "url": "https://www.linkedin.com/in/johanbjareholt/"
+            }
+        ],
+        "usageInfo": "https://docs.activitywatch.net/en/latest/getting-started.html#usage",
+        "discussionUrl": "https://forum.activitywatch.net/",
+        "releaseNotes": "https://activitywatch.net/timeline/",
+        "license": "https://www.mozilla.org/en-US/MPL/2.0/"
+    }
+</script>
+<!-- Schema End-->

--- a/_includes/schema-index.html
+++ b/_includes/schema-index.html
@@ -1,197 +1,197 @@
 <!-- Schema Start-->
 <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "SoftwareApplication",
-        "name": "ActivityWatch",
-        "url": "https://activitywatch.net/",
-        "description": "The best free and open-source automated time tracker: cross-platform, extensible, and privacy-focused. Ideal for freelancers and designed with ADHD users in mind.",
-        "disambiguatingDescription": "This app is designed for personal task and time management. It helps users efficiently organize their tasks and manage their time effectively. With features tailored to enhance productivity and streamline workflow, it ensures that users can stay on top of their schedules and prioritize their responsibilities with ease.",
-        "keywords": ["time management", "task management", "software", "free auto time tracker", "free freelancer time tracking software"],
-        "abstract": "A collection of trackers that monitor and log key activities on your computer, such as detecting if you are AFK or identifying the active window. A system for storing the data collected by these trackers. A flexible data format that meets most logging requirements. An ecosystem of tools that allows users to customize and extend the software to suit their needs.",
-        "alternativeHeadline": "A free automated time tracker designed to monitor your activity and screen time. This tool helps you keep an accurate record of how you spend your time on your computer, providing insights into your productivity and screen usage patterns. It's an essential tool for improving time management and boosting efficiency.",
-        "about": "ActivityWatch is a bundle of software that tracks your computer activity. You are, by default, the sole owner of your data. It also offers an ecosystem of software to work around it, including ways to collect more data and do different kinds of analysis. We created ActivityWatch completely free and open source so anyone can use, improve and extend it.",
-        "applicationCategory": "https://en.wikipedia.org/wiki/Time-tracking_software",
-        "applicationSubCategory": ["DesktopApplication", "MobileApplication", "WebApplication"],
-        "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": "4.2",
-            "reviewCount": "156"
-        },
-        "softwareVersion": "0.13.1",
-        "datePublished": "2024-06-12",
-        "dateCreated": "2016-06-10",
-        "downloadUrl": "https://activitywatch.net/downloads/",
-        "softwareHelp": "https://docs.activitywatch.net/en/latest/getting-started.html#installation",
-        "screenshot": "https://activitywatch.net/img/screenshots/screenshot-v0.9.3-activity.png",
-        "inLanguage": "en",
-        "featureList": [
-            "Application and window tracking",
-            "Usage categories",
-            "Browser extensions",
-            "Editor plugins (IDE)",
-            "Local and privacy first",
-            "Cross-platform",
-            "Synchronization"
-        ],
-        "audience": {
-            "@type": "Audience",
-            "audienceType": ["Business Professionals", "Freelancers", "Small Business", "ADHD individuals"]
-        },
-        "typicalAgeRange": "all ages",
-        "operatingSystem": ["Windows", "macOS", "Linux", "Android"],
-        "availableOnDevice": ["Desktop", "Mobile", "Tablet"],
-        "potentialAction": {
-            "@type": "ViewAction",
-            "target": [
-              "https://activitywatch.net/downloads/",
-              "android-app:https://play.google.com/store/apps/details?id=net.activitywatch.android",
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-windows-x86_64-setup.exe",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-windows-setup",
-                  "name": "ActivityWatch Windows Setup",
-                  "operatingSystem": "Windows"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-windows-x86_64.zip",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-windows-zip",
-                  "name": "ActivityWatch Windows Zip",
-                  "operatingSystem": "Windows"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://chocolatey.org/packages/activitywatch",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-chocolatey",
-                  "name": "ActivityWatch Chocolatey",
-                  "operatingSystem": "Windows"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-macos-x86_64.dmg",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-macos-dmg",
-                  "name": "ActivityWatch macOS DMG",
-                  "operatingSystem": "macOS"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-macos-x86_64.zip",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-macos-zip",
-                  "name": "ActivityWatch macOS Zip",
-                  "operatingSystem": "macOS"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://formulae.brew.sh/cask/activitywatch",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-homebrew",
-                  "name": "ActivityWatch Homebrew",
-                  "operatingSystem": "macOS"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-linux-x86_64.zip",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-linux-zip",
-                  "name": "ActivityWatch Linux Zip",
-                  "operatingSystem": "Linux"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-linux-x86_64.AppImage",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-linux-appimage",
-                  "name": "ActivityWatch Linux AppImage",
-                  "operatingSystem": "Linux"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://aur.archlinux.org/packages/activitywatch-bin/",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-arch-linux",
-                  "name": "ActivityWatch Arch Linux",
-                  "operatingSystem": "Linux"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://search.nixos.org/packages?query=activitywatch&show=activitywatch",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-nixos",
-                  "name": "ActivityWatch NixOS",
-                  "operatingSystem": "Linux"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://chrome.google.com/webstore/detail/nglaklhklhcoonedhgnpgddginnjdadi/",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-chrome",
-                  "name": "ActivityWatch Chrome Extension",
-                  "operatingSystem": "Chrome"
-                }
-              },
-              {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://addons.mozilla.org/en-US/firefox/addon/aw-watcher-web/",
-                "actionApplication": {
-                  "@type": "SoftwareApplication",
-                  "@id": "activitywatch-firefox",
-                  "name": "ActivityWatch Firefox Extension",
-                  "operatingSystem": "Firefox"
-                }
-              }
-            ]
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "ActivityWatch",
+    "url": "https://activitywatch.net/",
+    "description": "The best free and open-source automated time tracker: cross-platform, extensible, and privacy-focused. Ideal for freelancers and designed with ADHD users in mind.",
+    "disambiguatingDescription": "This app is designed for personal task and time management. It helps users efficiently organize their tasks and manage their time effectively. With features tailored to enhance productivity and streamline workflow, it ensures that users can stay on top of their schedules and prioritize their responsibilities with ease.",
+    "keywords": ["time management", "task management", "software", "free auto time tracker", "free freelancer time tracking software"],
+    "abstract": "A collection of trackers that monitor and log key activities on your computer, such as detecting if you are AFK or identifying the active window. A system for storing the data collected by these trackers. A flexible data format that meets most logging requirements. An ecosystem of tools that allows users to customize and extend the software to suit their needs.",
+    "alternativeHeadline": "A free automated time tracker designed to monitor your activity and screen time. This tool helps you keep an accurate record of how you spend your time on your computer, providing insights into your productivity and screen usage patterns. It's an essential tool for improving time management and boosting efficiency.",
+    "about": "ActivityWatch is a bundle of software that tracks your computer activity. You are, by default, the sole owner of your data. It also offers an ecosystem of software to work around it, including ways to collect more data and do different kinds of analysis. We created ActivityWatch completely free and open source so anyone can use, improve and extend it.",
+    "applicationCategory": "https://en.wikipedia.org/wiki/Time-tracking_software",
+    "applicationSubCategory": ["DesktopApplication", "MobileApplication", "WebApplication"],
+    "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.2",
+        "reviewCount": "156"
+    },
+    "softwareVersion": "0.13.1",
+    "datePublished": "2024-06-12",
+    "dateCreated": "2016-06-10",
+    "downloadUrl": "https://activitywatch.net/downloads/",
+    "softwareHelp": "https://docs.activitywatch.net/en/latest/getting-started.html#installation",
+    "screenshot": "https://activitywatch.net/img/screenshots/screenshot-v0.9.3-activity.png",
+    "inLanguage": "en",
+    "featureList": [
+        "Application and window tracking",
+        "Usage categories",
+        "Browser extensions",
+        "Editor plugins (IDE)",
+        "Local and privacy first",
+        "Cross-platform",
+        "Synchronization"
+    ],
+    "audience": {
+        "@type": "Audience",
+        "audienceType": ["Business Professionals", "Freelancers", "Small Business", "ADHD individuals"]
+    },
+    "typicalAgeRange": "all ages",
+    "operatingSystem": ["Windows", "macOS", "Linux", "Android"],
+    "availableOnDevice": ["Desktop", "Mobile", "Tablet"],
+    "potentialAction": {
+        "@type": "ViewAction",
+        "target": [
+          "https://activitywatch.net/downloads/",
+          "android-app:https://play.google.com/store/apps/details?id=net.activitywatch.android",
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-windows-x86_64-setup.exe",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-windows-setup",
+              "name": "ActivityWatch Windows Setup",
+              "operatingSystem": "Windows"
+            }
           },
-        "softwareRequirements": "Requires Windows 10 or later, macOS 10.15 or later, Linux kernel 5.4 or later, or Android 7.0 or later",
-        "creator": {
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-windows-x86_64.zip",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-windows-zip",
+              "name": "ActivityWatch Windows Zip",
+              "operatingSystem": "Windows"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://chocolatey.org/packages/activitywatch",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-chocolatey",
+              "name": "ActivityWatch Chocolatey",
+              "operatingSystem": "Windows"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-macos-x86_64.dmg",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-macos-dmg",
+              "name": "ActivityWatch macOS DMG",
+              "operatingSystem": "macOS"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-macos-x86_64.zip",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-macos-zip",
+              "name": "ActivityWatch macOS Zip",
+              "operatingSystem": "macOS"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://formulae.brew.sh/cask/activitywatch",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-homebrew",
+              "name": "ActivityWatch Homebrew",
+              "operatingSystem": "macOS"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-v0.13.1-linux-x86_64.zip",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-linux-zip",
+              "name": "ActivityWatch Linux Zip",
+              "operatingSystem": "Linux"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://github.com/ActivityWatch/activitywatch/releases/download/v0.13.1/activitywatch-linux-x86_64.AppImage",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-linux-appimage",
+              "name": "ActivityWatch Linux AppImage",
+              "operatingSystem": "Linux"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://aur.archlinux.org/packages/activitywatch-bin/",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-arch-linux",
+              "name": "ActivityWatch Arch Linux",
+              "operatingSystem": "Linux"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://search.nixos.org/packages?query=activitywatch&show=activitywatch",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-nixos",
+              "name": "ActivityWatch NixOS",
+              "operatingSystem": "Linux"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://chrome.google.com/webstore/detail/nglaklhklhcoonedhgnpgddginnjdadi/",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-chrome",
+              "name": "ActivityWatch Chrome Extension",
+              "operatingSystem": "Chrome"
+            }
+          },
+          {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://addons.mozilla.org/en-US/firefox/addon/aw-watcher-web/",
+            "actionApplication": {
+              "@type": "SoftwareApplication",
+              "@id": "activitywatch-firefox",
+              "name": "ActivityWatch Firefox Extension",
+              "operatingSystem": "Firefox"
+            }
+          }
+        ]
+      },
+    "softwareRequirements": "Requires Windows 10 or later, macOS 10.15 or later, Linux kernel 5.4 or later, or Android 7.0 or later",
+    "creator": {
+        "@type": "Person",
+        "name": "Erik Bjäreholt",
+        "url": "https://erik.bjareholt.com/",
+        "sameAs": "https://www.linkedin.com/in/erikbjareholt/"
+    },
+    "maintainer": [
+        {
             "@type": "Person",
             "name": "Erik Bjäreholt",
             "url": "https://erik.bjareholt.com/",
             "sameAs": "https://www.linkedin.com/in/erikbjareholt/"
         },
-        "maintainer": [
-            {
-                "@type": "Person",
-                "name": "Erik Bjäreholt",
-                "url": "https://erik.bjareholt.com/",
-                "sameAs": "https://www.linkedin.com/in/erikbjareholt/"
-            },
-            {
-                "@type": "Person",
-                "name": "Johan Bjäreholt",
-                "url": "https://www.linkedin.com/in/johanbjareholt/"
-            }
-        ],
-        "usageInfo": "https://docs.activitywatch.net/en/latest/getting-started.html#usage",
-        "discussionUrl": "https://forum.activitywatch.net/",
-        "releaseNotes": "https://activitywatch.net/timeline/",
-        "license": "https://www.mozilla.org/en-US/MPL/2.0/"
-    }
+        {
+            "@type": "Person",
+            "name": "Johan Bjäreholt",
+            "url": "https://www.linkedin.com/in/johanbjareholt/"
+        }
+    ],
+    "usageInfo": "https://docs.activitywatch.net/en/latest/getting-started.html#usage",
+    "discussionUrl": "https://forum.activitywatch.net/",
+    "releaseNotes": "https://activitywatch.net/timeline/",
+    "license": "https://www.mozilla.org/en-US/MPL/2.0/"
+}
 </script>
 <!-- Schema End-->


### PR DESCRIPTION
As mentioned in https://github.com/ActivityWatch/activitywatch.github.io/pull/35

I have made the changes to most of them.

Changes Made:
1)"Synchronization (We're working on it)" => "Synchronization".
2) Corrected creator's name.
3) Changed aggrRating=> 4.2(152).
4) Age Range => all age.
5) About 

Removed:
1) "fileSize": "82MB"
2) Funder, sponsors, contributors => After checking the master realized head is common for all pages and this info will be irrelevant to some of the pages like getting started, and timeline. 

Code I didn't change :
1)"usageInfo": "https://docs.activitywatch.net/en/latest/getting-started.html?highlight=usage#usage" 
(I have removed the highlight thingy  "https://docs.activitywatch.net/en/latest/getting-started.html?#usage" ) => For schemas, specific details help in SEO.
The same goes for softwareHelp.

Future Updates:
1) Schema Main Page (inProcess)
2) Download(Pending-1)
3) Documents(Pending-2)
4) Forum(Pending)
5) Blog(Pending)
6) Donate(Pending)
7) Stats(Pending-3)
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f2471cf346ab7a594891ceeea9e4127b75340e90  | 
|--------|--------|

### Summary:
Added JSON-LD schema to the main page for improved SEO, including detailed metadata about ActivityWatch.

**Key points**:
- Added JSON-LD schema for SEO in `_includes/schema-index.html`.
- Included `schema-index.html` in `_includes/head.pug`.
- Schema includes metadata: description, keywords, ratings, download links, etc.
- Removed `fileSize`, `funder`, `sponsors`, and `contributors` from schema.
- Corrected creator's name and updated rating value.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->