### PR TITLE
`README.md` link to docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ activitywatch.github.io
 
 [![Build Status](https://github.com/ActivityWatch/activitywatch.github.io/workflows/Build/badge.svg)](https://github.com/ActivityWatch/activitywatch.github.io/actions)
 
-Official ActivityWatch site
+Official [ActivityWatch][activitywatch] site
+
+https://activitywatch.net/ ➝ this repo  
+https://docs.activitywatch.net/ ➝ [ActivityWatch/docs][docs]
 
 ## Building
 
@@ -33,3 +36,6 @@ dest           | source
 Stats are generated for downloads (using https://github.com/ActivityWatch/stats/) and contributor statistics (using https://github.com/ActivityWatch/contributor-stats).
 
 If the stats are not up to date, then there may not have been a successful build in a while, and CI may have been disabled and needs to be manually triggered.
+
+[activitywatch]: https://github.com/ActivityWatch/activitywatch
+[docs]: https://github.com/ActivityWatch/docs


### PR DESCRIPTION
Make it easy to find docs repo from this repo, and clarify the role of each
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add links to the main site and documentation repo in `README.md`, clarifying their roles.
> 
>   - **Documentation Links**:
>     - Adds link to the main ActivityWatch site and the documentation repo in `README.md`.
>     - Clarifies the role of each link: `activitywatch.net` for the main site, `docs.activitywatch.net` for documentation.
>   - **Misc**:
>     - Updates the description of the official site to include a reference link to `[ActivityWatch][activitywatch]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Factivitywatch.github.io&utm_source=github&utm_medium=referral)<sup> for eb93724da4c1c1fe8b9e7c47be365970260980ca. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->