### PR TITLE
fix(contributors): remove stale gitgitlog link

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -53,10 +53,6 @@ permalink: /contributors/
 </p>
 
 <p>
-  GitGitLog also provides a view of the stats <a href="https://gitgitlog.com/ActivityWatch">here</a>.
-</p>
-
-<p>
   <small>
     <b>Note:</b>
     <i>


### PR DESCRIPTION
Removes the dead GitGitLog link from the contributors page.

Closes #45.