### PR TITLE
fix(stats): clarify March 2026 note wording

### DIFF
--- a/stats.pug
+++ b/stats.pug
@@ -26,11 +26,12 @@ div.text-center
   div.small.dim (Updated every 24 hours)
   p.small.text-left.mx-auto.mt-3(style="max-width: 42rem;")
     strong Note:
-    |  The dip around March 14-25, 2026 is not a broken chart. v0.13.2 was
-    |  temporarily marked as a pre-release, which sent
+    |  The dip around March 14-25, 2026 is not a broken chart. The raw data
+    |  really does show fewer downloads in that window, likely coinciding with
+    |  temporary pre/draft-release experiments around v0.13.2 that would have sent
     code  /releases/latest
-    |  traffic back to v0.13.1 and materially reduced downloads. A few March
-    |  collection runs also failed due to GitHub API rate limits, so short
+    |  traffic back to v0.13.1. A few March collection runs also failed due to
+    |  GitHub API rate limits, so short
     |  gaps are interpolated instead of being backfilled with guessed data.
 
 hr.my-5


### PR DESCRIPTION
## Summary
- keep the verified claim that the March 14-25, 2026 dip is real
- soften the v0.13.2 routing sentence from a definite causal claim to a likely explanation
- keep the rate-limit interpolation note unchanged

## Verification
- `git diff --check`
- attempted `bundle exec jekyll build`, but this clone still does not have the `jekyll` executable installed in the bundle environment
