### PR TITLE
[codex] fix(stats): soften March 2026 dip wording

### DIFF
--- a/stats.pug
+++ b/stats.pug
@@ -26,12 +26,14 @@ div.text-center
   div.small.dim (Updated every 24 hours)
   p.small.text-left.mx-auto.mt-3(style="max-width: 42rem;")
     strong Note:
-    |  The dip around March 14-25, 2026 is not a broken chart. v0.13.2 was
-    |  temporarily marked as a pre-release, which sent
+    |  The dip around March 14-25, 2026 is not a broken chart. Downloads
+    |  really did drop during that window. The most plausible explanation is
+    |  that v0.13.2 spent part of it marked as a pre-release, which would
+    |  have sent
     code  /releases/latest
-    |  traffic back to v0.13.1 and materially reduced downloads. A few March
-    |  collection runs also failed due to GitHub API rate limits, so short
-    |  gaps are interpolated instead of being backfilled with guessed data.
+    |  traffic back to v0.13.1 and reduced downloads. A few March collection
+    |  runs also failed due to GitHub API rate limits, so short gaps are
+    |  interpolated instead of being backfilled with guessed data.
 
 hr.my-5
 


### PR DESCRIPTION
## What changed
- soften the stats-page note so it separates measured facts from inference
- keep the March 2026 dip and GitHub API rate-limit interpolation notes
- stop stating the `/releases/latest` redirect mechanism as a proved fact

## Why
The data clearly shows a real downloads dip from March 14-25, 2026, and the March stats-collector failures due to GitHub API rate limits are already backed by ActivityWatch/stats#8. But the exact causal chain around `v0.13.2` temporarily being a pre-release is the most plausible explanation, not something the retained public data proves directly.

## Validation
- `git diff --check`
- verified the March 2026 download deltas from `ActivityWatch/stats` data
- verified the stats-collector fix landed in `ActivityWatch/stats#8`
