### PR TITLE
docs: clarify macOS release-specific support guidance

### DIFF
--- a/_includes/schema-faq.html
+++ b/_includes/schema-faq.html
@@ -41,7 +41,7 @@
       "name": "What platforms does ActivityWatch support?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ActivityWatch runs on Windows (10 and later), macOS (10.15+), Linux (most distributions), and Android. Browser extensions are available for Chrome and Firefox to track your web activity."
+        "text": "ActivityWatch runs on Windows, macOS, Linux, and Android. Browser extensions are available for Chrome and Firefox to track your web activity. macOS version and architecture support varies by release, so check the downloads page if you need a specific macOS build."
       }
     }
   ]

--- a/_includes/schema-index.html
+++ b/_includes/schema-index.html
@@ -89,7 +89,7 @@
           }
         ]
       },
-    "softwareRequirements": "Requires Windows 10 or later, macOS 10.15 or later, Linux kernel 5.4 or later, or Android 7.0 or later",
+    "softwareRequirements": "Requires Windows 10 or later, Linux kernel 5.4 or later, or Android 7.0 or later. macOS version and architecture support varies by release; see the downloads page for current macOS builds.",
     "creator": {
         "@type": "Person",
         "name": "Erik Bjäreholt",

--- a/downloads.pug
+++ b/downloads.pug
@@ -26,6 +26,8 @@ article.container
   div For help on how to get started, see the #[a(href="https://docs.activitywatch.net/en/latest/getting-started.html") Getting Started guide] in the documentation.
 
   div Looking for an older or pre-release version? You can find all #[a(href="https://github.com/ActivityWatch/activitywatch/releases") releases on GitHub].
+  p.mt-2
+    | macOS support varies by release. If you need a specific macOS version or Intel/Apple Silicon build, check the GitHub release assets before installing. The latest stable download on this page may differ from current prerelease or nightly macOS builds.
 
   h3.mt-3 Nightly builds
   p

--- a/index.pug
+++ b/index.pug
@@ -137,7 +137,7 @@ div.container
 
       h3 What platforms does ActivityWatch support?
       p
-        | ActivityWatch runs on #[b Windows] (10 and later), #[b macOS] (10.15+), #[b Linux] (most distributions), and #[b Android]. Browser extensions are available for Chrome and Firefox to track your web activity.
+        | ActivityWatch runs on #[b Windows], #[b macOS], #[b Linux], and #[b Android]. Browser extensions are available for Chrome and Firefox to track your web activity. macOS version and architecture support varies by release, so check the #[a(href="/downloads/") downloads page] if you need a specific macOS build.
 
       p.mt-3
         | For more answers, see the #[a(href="https://docs.activitywatch.net/en/latest/faq.html") full FAQ in the documentation].


### PR DESCRIPTION
## Summary
- remove the homepage FAQ claim that all macOS support is `10.15+`
- update the schema markup to stop advertising a single hard-coded macOS floor
- add a downloads-page note telling users to verify macOS architecture/version requirements per release

## Why
`ActivityWatch/activitywatch#1294` surfaced that the public site was overpromising a single macOS minimum version. The current release lines do not share one universal macOS floor, so the old copy was misleading.

## Impact
Users looking for Catalina/Intel compatibility get pointed at the release assets instead of a wrong blanket claim.

## Validation
- confirmed the stale `10.15+` copy in this repo before editing
- inspected release assets for `ActivityWatch/activitywatch`
- verified the stable `v0.13.2` macOS `x86_64` binary advertises `LC_VERSION_MIN_MACOSX 10.13.0`
- verified the prerelease `v0.14.0b1` macOS `arm64` binary advertises `LC_BUILD_VERSION minos 11.0.0`

Related to ActivityWatch/activitywatch#1294.
