### PR TITLE
stats: show downloads chart per-week instead of per-day

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ img/stats: stats
 	cd stats && poetry install
 	mkdir -p img/stats
 	mkdir -p stats/out
-	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column downloads --per-day --save ../img/stats/downloads.png
+	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column downloads --per-week --save ../img/stats/downloads.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Chrome WAU' --title 'Chrome Weekly Active Users' --save ../img/stats/chrome-wau.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Firefox DAU' --resample 7D --title 'Firefox Daily Active Users (7D mean)' --save ../img/stats/firefox-dau-7d.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Android installed devices' --title 'Android Installed Devices' --save ../img/stats/android-devices.png


### PR DESCRIPTION
The downloads chart (`img/stats/downloads.png`) bottom subplot reads better as a weekly rate (~9k/week) than a daily one (~1.3k/day), matching what it showed before the recent ActivityWatch/stats refactor.

Both `--per-day` and `--per-week` now render a 7d-rolling-smoothed line (after the stats-repo smoothing fix), so this is purely a display/magnitude choice. One-line Makefile change.