### PR TITLE
stats: self-host stargazers chart (fix broken starchart.cc embed)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ img/stats: stats
 	mkdir -p img/stats
 	mkdir -p stats/out
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column downloads --per-week --save ../img/stats/downloads.png
+	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column stars --title 'GitHub Stargazers' --save ../img/stats/stars.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Chrome WAU' --title 'Chrome Weekly Active Users' --save ../img/stats/chrome-wau.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Firefox DAU' --resample 7D --title 'Firefox Daily Active Users (7D mean)' --save ../img/stats/firefox-dau-7d.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Android installed devices' --title 'Android Installed Devices' --save ../img/stats/android-devices.png

--- a/stats.pug
+++ b/stats.pug
@@ -64,10 +64,10 @@ div.text-center
   p
     | How many people have starred the ActivityWatch repository on GitHub
   div.img-center
-    a(href="https://starchart.cc/ActivityWatch/activitywatch")
-      img.width-700(title="Stargazers over time" src="https://starchart.cc/ActivityWatch/activitywatch.svg")
+    a(href="https://github.com/ActivityWatch/activitywatch/stargazers")
+      img.width-700(title="Stargazers over time" src="/img/stats/stars.png")
   div.small.dim
-    | Provided by starchart.cc
+    | Tracked in ActivityWatch/stats, updated every 6h
 
 hr.my-5
 


### PR DESCRIPTION
## Problem

The Stargazers chart on `/stats/` is broken: it embeds `starchart.cc/ActivityWatch/activitywatch.svg`, and [GitHub now restricts the stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) to a repo's admins/collaborators — third-party services like starchart.cc / star-history.com can't read it anymore without a per-user token.

## Fix

We already collect star counts in [ActivityWatch/stats](https://github.com/ActivityWatch/stats) — `data/stats.csv`, every 6h, with **complete history from 0 stars (2016) to ~18k today** (daily granularity 2017–2020, 6-hourly since). So render the chart ourselves via `analyze_stats.py --column stars`, exactly like the downloads/Chrome/Firefox/Android images. No external dependency, no token needed.

- Makefile: add a `stars.png` render step.
- stats.pug: swap the starchart.cc `<img>` for `/img/stats/stars.png`, linking to the GitHub stargazers page.

Rendered output is a clean cumulative curve identical in shape to what starchart.cc showed.

**On backfilling:** not needed — our tracked data already covers the full history from project start. (If we ever wanted to reconstruct/verify, the GitHub stargazers endpoint with `Accept: application/vnd.github.star+json` returns each stargazer's `starred_at` and still works for repo admins with a token — but it only counts *current* stargazers, so it's actually less accurate than our point-in-time tracking.)