### PR TITLE
chore: bump checkout@v2->v4 and setup-python@v1->v5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,13 @@ jobs:
         python_version: ['3.12']
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@v4 # persist-credentials must be false so the deploy step below uses its own token, not the checkout credentials.
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
 


### PR DESCRIPTION
Both actions were being forced onto Node 24 with deprecation warnings (Node 20 is EOL on GitHub runners). No behavior change; `persist-credentials: false` retained so the deploy step keeps using its own token.