### PR TITLE
chore: bump checkout->v5, setup-python->v6 (Node 24 native)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,13 @@ jobs:
         python_version: ['3.12']
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4 # persist-credentials must be false so the deploy step below uses its own token, not the checkout credentials.
+        uses: actions/checkout@v5 # persist-credentials must be false so the deploy step below uses its own token, not the checkout credentials.
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
 


### PR DESCRIPTION
Follow-up to the v2->v4 / v1->v5 bump: v4/v5 still target Node 20 and get force-run on Node 24 with a deprecation warning. v5/v6 are Node-24-native and clear it. (The remaining Node-20 warning is from JamesIves/github-pages-deploy-action@4.1.8, out of scope here.)