### PR TITLE
stats: add Android rating + crash-rate charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,5 @@ img/stats: stats
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Chrome WAU' --title 'Chrome Weekly Active Users' --save ../img/stats/chrome-wau.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Firefox DAU' --resample 7D --title 'Firefox Daily Active Users (7D mean)' --save ../img/stats/firefox-dau-7d.png
 	cd stats && poetry run python analyze_stats.py --since 2017-07-01 --column 'Android installed devices' --title 'Android Installed Devices' --save ../img/stats/android-devices.png
+	cd stats && poetry run python analyze_stats.py --since 2019-01-01 --column 'Android Play Store rating' --title 'Android Play Store Rating' --save ../img/stats/android-rating.png
+	cd stats && poetry run python analyze_stats.py --since 2025-06-01 --column 'Android crash rate (%)' --title 'Android Crash Rate (user-perceived, %)' --save ../img/stats/android-crash-rate.png

--- a/stats.pug
+++ b/stats.pug
@@ -57,7 +57,7 @@ div.text-center
     img.width-500(src="/img/stats/android-devices.png")
     img.width-500(src="/img/stats/android-rating.png")
     img.width-500(src="/img/stats/android-crash-rate.png")
-  div.small.dim (Auto-updated daily from the Play Console)
+  div.small.dim (Auto-updated daily when Play Console data is available; ratings lag ~1 month)
 
 hr.my-5
 

--- a/stats.pug
+++ b/stats.pug
@@ -52,10 +52,12 @@ div.text-center
 
   h4.mt-5 Android app
   p
-    | How many active installations there are of the Android app
+    | Install base, Play Store rating, and crash rate for the Android app
   div.img-center
     img.width-500(src="/img/stats/android-devices.png")
-  div.small.dim (Updated manually on an irregular basis)
+    img.width-500(src="/img/stats/android-rating.png")
+    img.width-500(src="/img/stats/android-crash-rate.png")
+  div.small.dim (Auto-updated daily from the Play Console)
 
 hr.my-5
 


### PR DESCRIPTION
Adds two charts to the Android section of /stats/, from the now-auto-collected data in ActivityWatch/stats:
- **Play Store rating** over time (2019→) — shows the recent drop from ~4.2 to ~3.1
- **User-perceived crash rate** (2025-06→)

Also fixes the stale 'updated manually' note (the whole Android section is auto-updated daily now).