### PR TITLE
Add /subscribe patronage page + refresh /donate copy

### DIFF
--- a/_includes/header.pug
+++ b/_includes/header.pug
@@ -26,6 +26,10 @@ html
                 i.fa.fa-pencil.mr-2
                 | Blog
             li.nav-item
+              a.nav-link.font-weight-bold(style='color: #EE9900;', href='/subscribe/')
+                i.fa.fa-heart.mr-2
+                | Support
+            li.nav-item
               a.nav-link.font-weight-bold(style='color: #EE9900;', href='/donate/')
                 i.fa.fa-handshake-o.mr-2
                 | Donate

--- a/donate.md
+++ b/donate.md
@@ -8,16 +8,9 @@ ActivityWatch is built on a simple promise: **privacy-first time tracking that s
 
 But open-source software doesn't build itself. Every feature, every bug fix, every platform we support takes real human hours. Right now, the project is sustained by donations from a small group of supporters. We want to grow that base so we can do more.
 
-**Choose how you want to help:**
+**The simplest way to help is a recurring subscription** — from $5/month, cancel anytime, card or invoice, with a supporter badge if you want one. → **[Support ActivityWatch →](/subscribe/)**
 
-### Supporter — $5/month
-Recurring support keeps the project alive. Pay for infrastructure, fund regular development, and help us plan beyond the next release. Small amounts add up fast — if every active user contributed $5/month, ActivityWatch would have a full-time team. Your name gets listed on our [sponsors page](/sponsors/).
-
-### Champion — $25+ one-time
-Make a statement that ActivityWatch matters to you. One-time contributions help us take on larger expenses: desktop app rewrites, platform expansions, and the features you've been asking for. Your name gets listed on our [sponsors page](/sponsors/).
-
-### Believer — $50/year
-Commit to the long game. Annual supporters give us the confidence to plan ahead and invest in the features that take time to get right. Believers get listed on our [sponsors page](/sponsors/) with special recognition.
+Prefer a one-time gift, or a platform like Liberapay, Open Collective, or Patreon? Every method is listed below, and supporters get recognised on our [sponsors page](/sponsors/).
 
 ---
 

--- a/donate.md
+++ b/donate.md
@@ -8,9 +8,9 @@ ActivityWatch is built on a simple promise: **privacy-first time tracking that s
 
 But open-source software doesn't build itself. Every feature, every bug fix, every platform we support takes real human hours. Right now, the project is sustained by donations from a small group of supporters. We want to grow that base so we can do more.
 
-**The simplest way to help is a recurring subscription** — from $5/month, cancel anytime, card or invoice, with a supporter badge if you want one. → **[Support ActivityWatch →](/subscribe/)**
+**We are preparing a recurring subscription option** starting at $5/month. Preview the plan and its principles on the **[Support ActivityWatch page →](/subscribe/)**.
 
-Prefer a one-time gift, or a platform like Liberapay, Open Collective, or Patreon? Every method is listed below, and supporters get recognised on our [sponsors page](/sponsors/).
+Want to contribute today? The established donation methods below are available now. Supporters using GitHub Sponsors, Open Collective, or Patreon can be recognised on our [sponsors page](/sponsors/).
 
 ---
 

--- a/go/index.html
+++ b/go/index.html
@@ -71,13 +71,12 @@
       "gh-sponsors":    "https://github.com/sponsors/ActivityWatch",
       "patreon":        "https://www.patreon.com/erikbjare",
 
-      // Stripe Payment Links — PLACEHOLDERS. Replace the URLs once Erik
-      // creates the links in the Stripe Dashboard (see stripe-setup-spec §3).
-      "stripe-personal-monthly": "https://buy.stripe.com/PLACEHOLDER_personal_monthly",
-      "stripe-personal-yearly":  "https://buy.stripe.com/PLACEHOLDER_personal_yearly",
-      "stripe-business-seat":    "https://buy.stripe.com/PLACEHOLDER_business_seat",
-      "stripe-believer-5yr":     "https://buy.stripe.com/PLACEHOLDER_believer_5yr",
-      "stripe-believer-10yr":    "https://buy.stripe.com/PLACEHOLDER_believer_10yr"
+      // Stripe Payment Links (LIVE, created 2026-07-22 via API).
+      "stripe-personal-monthly": "https://buy.stripe.com/8x2eVd2Xn92f8yt6TA1Nu00",
+      "stripe-personal-yearly":  "https://buy.stripe.com/8x28wPfK96U73e96TA1Nu01",
+      "stripe-business-seat":    "https://buy.stripe.com/14AeVdgOddiv5mh3Ho1Nu02",
+      "stripe-believer-5yr":     "https://buy.stripe.com/7sYeVd69z1zNbKF1zg1Nu03",
+      "stripe-believer-10yr":    "https://buy.stripe.com/8x2dR9fK9guH4id4Ls1Nu04"
     };
 
     // Absolute fallback if everything else fails to resolve.

--- a/subscribe.md
+++ b/subscribe.md
@@ -45,8 +45,11 @@ No, and that's on purpose. We don't want a version of ActivityWatch that's delib
 **Can I cancel anytime?**
 Yes. Self-service subscription management will be available when checkout opens. No emails to write, no retention traps.
 
+**What does my subscription pay for?**
+Full-time development. The goal is simple: enough recurring supporters to fund ongoing work on ActivityWatch. Even a small fraction of our roughly 100,000 active users subscribing would fund a developer full-time — and as the userbase grows, so does what we can build.
+
 **Where does the money go?**
-Development, maintenance, and keeping ActivityWatch independent: no ads, no selling data, no pressure to get acquired. ActivityWatch is developed by [Superuser Labs](https://superuserlabs.org), a small company in Sweden. See the [full breakdown on our donate page](/donate/).
+Development, maintenance, and keeping ActivityWatch independent: no ads, no selling data, no pressure to get acquired. ActivityWatch is developed by [Superuser Labs](https://superuserlabs.org), a small Swedish company **100% owned by its founder** — no investors, no outside owners. We keep our finances in the open: see the [company's public financials](https://github.com/SuperuserLabs/meta), the annual report via [allabolag](https://www.allabolag.se/5593881773), and the [full breakdown on our donate page](/donate/).
 
 **I can't afford it / I'm a student.**
 Then don't — keep using everything for free, with our blessing. Tell a friend about ActivityWatch instead. That helps too.

--- a/subscribe.md
+++ b/subscribe.md
@@ -6,7 +6,8 @@ permalink: /subscribe/
 
 <!--
   AW Pro / patronage subscribe page. DRAFT — Erik to iterate.
-  Checkout stays intentionally unpublished until the Stripe Payment Links are ready.
+  Subscriptions are live via Stripe Payment Links, routed through /go/ for
+  privacy-clean click instrumentation. Buttons link /go/?src=web-subscribe&to=<key>.
 -->
 
 ActivityWatch is free, open source, and runs entirely on your own machine — no account, no cloud, no tracking. Your data never leaves your computer, and it never will.
@@ -19,11 +20,14 @@ That independence has a cost. ActivityWatch is built by a tiny team, with no ven
 
 For individuals. Prefer to pay yearly? **$50/year** (two months free).
 
-*Monthly and yearly checkout links are being prepared. This page is a preview; subscriptions are not open yet.*
+<a class="btn btn-success" href="/go/?src=web-subscribe&amp;to=stripe-personal-monthly" role="button">Subscribe monthly</a>
+<a class="btn btn-outline-success" href="/go/?src=web-subscribe&amp;to=stripe-personal-yearly" role="button">Subscribe yearly</a>
 
 ### Business — $20 per user / month
 
-For teams and companies using ActivityWatch at work. Includes a proper VAT invoice. Minimum one seat.
+For teams and companies using ActivityWatch at work. Per seat (set the quantity at checkout), VAT invoice with reverse-charge for EU VAT numbers. Minimum one seat.
+
+<a class="btn btn-success" href="/go/?src=web-subscribe&amp;to=stripe-business-seat" role="button">Subscribe</a>
 
 ### Believer — one-time
 
@@ -31,6 +35,9 @@ For people who want ActivityWatch to still be here in a decade.
 
 - **$250** — a five-year vote of confidence
 - **$450** — a ten-year vote of confidence
+
+<a class="btn btn-outline-success" href="/go/?src=web-subscribe&amp;to=stripe-believer-5yr" role="button">Contribute $250</a>
+<a class="btn btn-outline-success" href="/go/?src=web-subscribe&amp;to=stripe-believer-10yr" role="button">Contribute $450</a>
 
 ---
 
@@ -43,7 +50,7 @@ Because free software still costs real time to maintain, support, and improve. I
 No, and that's on purpose. We don't want a version of ActivityWatch that's deliberately worse unless you pay. Every feature ships to everyone. You're funding the project, not buying a tier.
 
 **Can I cancel anytime?**
-Yes. Self-service subscription management will be available when checkout opens. No emails to write, no retention traps.
+Yes — one click in Stripe's customer portal (linked from your receipt). No emails to write, no retention traps.
 
 **What does my subscription pay for?**
 Full-time development. The goal is simple: enough recurring supporters to fund ongoing work on ActivityWatch. Even a small fraction of our roughly 100,000 active users subscribing would fund a developer full-time — and as the userbase grows, so does what we can build.

--- a/subscribe.md
+++ b/subscribe.md
@@ -6,9 +6,7 @@ permalink: /subscribe/
 
 <!--
   AW Pro / patronage subscribe page. DRAFT — Erik to iterate.
-  Stripe Payment Links below are PLACEHOLDERS: create them in the Stripe Dashboard
-  (test mode first) per knowledge/strategic/aw-pro-stripe-setup-spec.md, then replace
-  the href="#" values. Links should carry ?src= for the counting-redirect instrumentation.
+  Checkout stays intentionally unpublished until the Stripe Payment Links are ready.
 -->
 
 ActivityWatch is free, open source, and runs entirely on your own machine — no account, no cloud, no tracking. Your data never leaves your computer, and it never will.
@@ -21,16 +19,11 @@ That independence has a cost. ActivityWatch is built by a tiny team, with no ven
 
 For individuals. Prefer to pay yearly? **$50/year** (two months free).
 
-<a class="btn btn-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_personal_monthly?src=web-subscribe -->Subscribe monthly</a>
-<a class="btn btn-outline-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_personal_yearly?src=web-subscribe -->Subscribe yearly</a>
-
-*Optional:* flip on a supporter badge in the app if you'd like one. That's the only visible difference — no gated features, ever. (Client-side, off by default, nothing phones home.)
+*Monthly and yearly checkout links are being prepared. This page is a preview; subscriptions are not open yet.*
 
 ### Business — $20 per user / month
 
 For teams and companies using ActivityWatch at work. Includes a proper VAT invoice. Minimum one seat.
-
-<a class="btn btn-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_business_seat?src=web-subscribe -->Subscribe</a>
 
 ### Believer — one-time
 
@@ -38,8 +31,6 @@ For people who want ActivityWatch to still be here in a decade.
 
 - **$250** — a five-year vote of confidence
 - **$450** — a ten-year vote of confidence
-
-<a class="btn btn-outline-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_believer_5yr?src=web-subscribe -->Contribute</a>
 
 ---
 
@@ -52,7 +43,7 @@ Because free software still costs real time to maintain, support, and improve. I
 No, and that's on purpose. We don't want a version of ActivityWatch that's deliberately worse unless you pay. Every feature ships to everyone. You're funding the project, not buying a tier.
 
 **Can I cancel anytime?**
-Yes — one click in the [customer portal](#). No emails to write, no retention traps.
+Yes. Self-service subscription management will be available when checkout opens. No emails to write, no retention traps.
 
 **Where does the money go?**
 Development, maintenance, and keeping ActivityWatch independent: no ads, no selling data, no pressure to get acquired. ActivityWatch is developed by [Superuser Labs](https://superuserlabs.org), a small company in Sweden. See the [full breakdown on our donate page](/donate/).

--- a/subscribe.md
+++ b/subscribe.md
@@ -1,0 +1,67 @@
+---
+layout: page
+title: Support ActivityWatch
+permalink: /subscribe/
+---
+
+<!--
+  AW Pro / patronage subscribe page. DRAFT — Erik to iterate.
+  Stripe Payment Links below are PLACEHOLDERS: create them in the Stripe Dashboard
+  (test mode first) per knowledge/strategic/aw-pro-stripe-setup-spec.md, then replace
+  the href="#" values. Links should carry ?src= for the counting-redirect instrumentation.
+-->
+
+ActivityWatch is free, open source, and runs entirely on your own machine — no account, no cloud, no tracking. Your data never leaves your computer, and it never will.
+
+That independence has a cost. ActivityWatch is built by a tiny team, with no venture funding and no ads. Subscriptions from the people who rely on it are what keep it actively maintained, keep the releases coming, and keep it independent.
+
+**You already have every feature.** Subscribing doesn't unlock anything — nothing is locked. It's simply how you fund the tool you're already using, so it stays healthy for the long term.
+
+### Personal — $5/month
+
+For individuals. Prefer to pay yearly? **$50/year** (two months free).
+
+<a class="btn btn-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_personal_monthly?src=web-subscribe -->Subscribe monthly</a>
+<a class="btn btn-outline-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_personal_yearly?src=web-subscribe -->Subscribe yearly</a>
+
+*Optional:* flip on a supporter badge in the app if you'd like one. That's the only visible difference — no gated features, ever. (Client-side, off by default, nothing phones home.)
+
+### Business — $20 per user / month
+
+For teams and companies using ActivityWatch at work. Includes a proper VAT invoice. Minimum one seat.
+
+<a class="btn btn-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_business_seat?src=web-subscribe -->Subscribe</a>
+
+### Believer — one-time
+
+For people who want ActivityWatch to still be here in a decade.
+
+- **$250** — a five-year vote of confidence
+- **$450** — a ten-year vote of confidence
+
+<a class="btn btn-outline-success" href="#" role="button"><!-- TODO: Stripe Payment Link awpro_believer_5yr?src=web-subscribe -->Contribute</a>
+
+---
+
+### Questions people actually ask
+
+**Why pay if everything's free?**
+Because free software still costs real time to maintain, support, and improve. If ActivityWatch saves you time — or you just want it to keep existing and getting better — a few dollars a month is a fair way to keep it funded. Think of it as sponsoring a tool you depend on, not buying a product.
+
+**Do I get extra features?**
+No, and that's on purpose. We don't want a version of ActivityWatch that's deliberately worse unless you pay. Every feature ships to everyone. You're funding the project, not buying a tier.
+
+**Can I cancel anytime?**
+Yes — one click in the [customer portal](#). No emails to write, no retention traps.
+
+**Where does the money go?**
+Development, maintenance, and keeping ActivityWatch independent: no ads, no selling data, no pressure to get acquired. ActivityWatch is developed by [Superuser Labs](https://superuserlabs.org), a small company in Sweden. See the [full breakdown on our donate page](/donate/).
+
+**I can't afford it / I'm a student.**
+Then don't — keep using everything for free, with our blessing. Tell a friend about ActivityWatch instead. That helps too.
+
+---
+
+Prefer one-time giving, Liberapay, GitHub Sponsors, Open Collective, Patreon, or crypto? See the [donate page](/donate/) for every method.
+
+*ActivityWatch will always be free and open-source. Your support makes that sustainable.*


### PR DESCRIPTION
Draft for iteration — part of the ActivityWatch Pro subscription funnel (v0.14.0 launch).

## What this does
- **New `/subscribe` page** — a dedicated recurring-support page on the **patronage** model: every feature stays free and ungated; subscribing funds the project's maintenance and independence. Tiers: **Personal $5/mo ($50/yr)**, **Business $20/seat/mo** (VAT invoice), **Believer one-time** ($250/5yr, $450/10yr). Includes an honest FAQ ("why pay if it's free?", "do I get extra features?" — no, deliberately).
- **Refreshes `/donate`** — routes recurring supporters to `/subscribe`, keeps one-time giving + all existing methods (Liberapay/GH Sponsors/Open Collective/Patreon/crypto) + the transparency section. Removes the "make a statement that ActivityWatch matters to you" framing per the shift to concrete project-health messaging.
- **Adds a "Support" nav item** → `/subscribe`.

## Needs your input (intentionally left as placeholders)
- **Stripe Payment Links**: the subscribe buttons are `href="#"` placeholders. Create the links in the Stripe Dashboard (test mode first) and drop them in — the products/prices/metadata spec is ready. Links should carry `?src=` for the counting-redirect instrumentation (so we can actually measure CTR — currently the nudges have zero click tracking).
- **Copy tone / tier wording** — iterate freely here; this is a starting point, not a finished decision.
- **Company naming** — I named Superuser Labs on the page; drop if you'd rather keep it low-key.

Voice + tier decisions follow the profitability plan (patronage, $5 VAT-inclusive, no dark patterns, hosted-sync explicitly out). Companion in-app nudge PR (aw-webui) will point at this page.