### PR TITLE
Add /go/ nudge-click counting redirect (privacy-clean CTR instrumentation)

### DIFF
--- a/go/index.html
+++ b/go/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<!--
+  ActivityWatch nudge-click counting redirect  (/go/)
+  ----------------------------------------------------
+  Privacy-clean: counts a per-`src` click via the site's EXISTING Google
+  Analytics (GA4 property G-SNPLMVFB8V), then forwards to a HARDCODED
+  destination. No IPs, user-agents, or per-user IDs are stored by us — GA
+  aggregates the `nudge_click` event by its `src` dimension only.
+
+  Open-redirect guard: this page NEVER navigates to a caller-supplied URL.
+  `?to=` is a KEY into the DESTINATIONS map below, not a URL. The only URLs
+  that can ever reach location.replace() are the literal strings hardcoded
+  here. Unknown src/to values fall back to a safe default.
+
+  Deploy: drop this file at the site repo root as `go/index.html`. It has NO
+  Jekyll front matter on purpose, so Jekyll copies it verbatim (no layout,
+  no Liquid processing) and serves it at https://activitywatch.net/go/.
+
+  Usage:
+    /go/?src=inapp-home                -> src default destination (subscribe)
+    /go/?src=survey                    -> survey Google Form
+    /go/?src=web-subscribe&to=stripe-personal-monthly  -> explicit dest key
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Redirecting…</title>
+  <!-- Reuse the site's existing GA4 property. No new analytics vendor. -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SNPLMVFB8V"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    // send_page_view:false — this hop is not a real pageview; we only want
+    // the explicit nudge_click event, to keep GA reports clean.
+    gtag('config', 'G-SNPLMVFB8V', { 'send_page_view': false });
+  </script>
+  <style>
+    html,body{height:100%;margin:0}
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      display:flex;align-items:center;justify-content:center;
+      background:#fff;color:#333}
+    @media (prefers-color-scheme:dark){body{background:#1a1a1a;color:#ccc}}
+    a{color:#EE9900}
+  </style>
+</head>
+<body>
+  <p>Redirecting… If nothing happens, <a id="fallback" href="https://activitywatch.net/subscribe">continue here</a>.</p>
+
+  <script>
+  (function () {
+    "use strict";
+
+    // ---- HARDCODED destination allowlist (open-redirect guard) ----------
+    // The ONLY URLs this page can ever navigate to. Add a key here, never
+    // accept a raw URL from the query string.
+    var DESTINATIONS = {
+      // On-site (GA also sees these as pageviews, but routing through /go/
+      // gives a single unified nudge_click event with a `src` dimension).
+      "subscribe":      "https://activitywatch.net/subscribe",
+      "donate":         "https://activitywatch.net/donate",
+
+      // Off-site — GA CANNOT instrument these directly; this redirect is the
+      // only way to count clicks to them.
+      "survey":         "https://forms.gle/q2N9K5RoERBV8kqPA",
+      "forum":          "https://forum.activitywatch.net",
+      "opencollective": "https://opencollective.com/activitywatch",
+      "liberapay":      "https://liberapay.com/ActivityWatch/",
+      "gh-sponsors":    "https://github.com/sponsors/ActivityWatch",
+      "patreon":        "https://www.patreon.com/erikbjare",
+
+      // Stripe Payment Links — PLACEHOLDERS. Replace the URLs once Erik
+      // creates the links in the Stripe Dashboard (see stripe-setup-spec §3).
+      "stripe-personal-monthly": "https://buy.stripe.com/PLACEHOLDER_personal_monthly",
+      "stripe-personal-yearly":  "https://buy.stripe.com/PLACEHOLDER_personal_yearly",
+      "stripe-business-seat":    "https://buy.stripe.com/PLACEHOLDER_business_seat",
+      "stripe-believer-5yr":     "https://buy.stripe.com/PLACEHOLDER_believer_5yr",
+      "stripe-believer-10yr":    "https://buy.stripe.com/PLACEHOLDER_believer_10yr"
+    };
+
+    // Absolute fallback if everything else fails to resolve.
+    var SAFE_DEFAULT = "subscribe";
+
+    // ---- src taxonomy -> default destination key ------------------------
+    // A nudge can point at /go/?src=<tag> with no `to=` and land correctly.
+    var SRC_DEFAULT = {
+      "inapp-home":    "subscribe",
+      "inapp-report":  "subscribe",
+      "inapp-banner":  "subscribe",
+      "inapp-about":   "donate",
+      "download":      "subscribe",
+      "web-subscribe": "subscribe",
+      "donate":        "donate",
+      "forum":         "forum",
+      "survey":        "survey"
+    };
+
+    // Known src values. Anything else is recorded as "other" so a crafted
+    // query string can't inflate GA cardinality or smuggle PII into `src`.
+    var KNOWN_SRC = Object.keys(SRC_DEFAULT);
+
+    var params = new URLSearchParams(window.location.search);
+
+    // Sanitize + classify src. Never echo an arbitrary string into GA.
+    var rawSrc = (params.get("src") || "").toLowerCase().replace(/[^a-z0-9-]/g, "");
+    var src = KNOWN_SRC.indexOf(rawSrc) !== -1 ? rawSrc : "other";
+
+    // Resolve destination KEY: explicit ?to= (must be an allowlisted key) >
+    // src default > safe default. A raw URL in ?to= can never match a key,
+    // so it is silently ignored — no open redirect is possible.
+    var toKey = (params.get("to") || "").toLowerCase().replace(/[^a-z0-9-]/g, "");
+    var destKey =
+      (Object.prototype.hasOwnProperty.call(DESTINATIONS, toKey) && toKey) ||
+      SRC_DEFAULT[rawSrc] ||
+      SAFE_DEFAULT;
+
+    var destUrl = DESTINATIONS[destKey] || DESTINATIONS[SAFE_DEFAULT];
+
+    // Keep the fallback link in sync with the resolved destination.
+    var fb = document.getElementById("fallback");
+    if (fb) { fb.setAttribute("href", destUrl); }
+
+    // ---- fire the count, then forward -----------------------------------
+    var redirected = false;
+    function go() {
+      if (redirected) { return; }
+      redirected = true;
+      window.location.replace(destUrl);
+    }
+
+    // trackNudgeClick — the ONE place the analytics vendor lives. To switch
+    // from GA4 to PostHog (or anything else) later, replace only this function
+    // body: call the new vendor's capture with { src, dest } and invoke done()
+    // in its callback. Everything else (routing, allowlist, guards) is
+    // vendor-agnostic. `done` navigates as soon as the hit is queued.
+    function trackNudgeClick(src, dest, done) {
+      try {
+        gtag('event', 'nudge_click', {
+          'src': src,            // the counted dimension
+          'dest': dest,          // where it went (allowlist key, not a URL)
+          'transport_type': 'beacon',
+          'event_callback': done // navigate as soon as the hit is queued
+        });
+      } catch (e) {
+        // Vendor blocked / failed to load — still forward the user.
+        done();
+      }
+    }
+
+    trackNudgeClick(src, destKey, go);
+
+    // Belt-and-suspenders: never let a blocked/slow tracker hang the redirect.
+    setTimeout(go, 400);
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
The instrumentation half of the AW Pro nudge funnel — lets us finally measure nudge click-through (existing nudges have zero click tracking today).

## What it is
A single static page at `activitywatch.net/go/` (`go/index.html`, no Jekyll front matter so it's served verbatim). A nudge links to `/go/?src=<tag>`; the page records a per-`src` `nudge_click` event via **the site's existing GA4 property** (`G-SNPLMVFB8V` — no new analytics vendor, no new infra), then forwards to a hardcoded destination.

## Why a redirect hop (vs just `?src=` on the real link)
A direct link to `/subscribe?src=inapp-home` only produces a **pageview** — you can't tell nudge clicks apart, and you get **nothing** for off-site destinations (survey, forum, Stripe links). Routing through `/go/` gives one unified `nudge_click` event with a `src` dimension, and is the *only* way to count clicks to off-site targets.

## Privacy & safety
- **Privacy-clean:** counts `src` only — no IPs, user-agents, or per-user IDs stored by us. Unknown `src` is recorded as `other` so a crafted query can't smuggle PII or inflate cardinality.
- **Open-redirect-safe:** `?to=` is a **key into a hardcoded allowlist map, never a URL** — the only strings that can reach `location.replace()` are literals in the file. A raw URL in `?to=` can never match a key.
- Reliability: fires with beacon transport + `event_callback`, with a 400ms timeout fallback so a blocked/slow tracker never hangs the redirect.
- **Vendor-swappable:** all analytics live in one `trackNudgeClick()` function — switching to PostHog later is a single-function change.

## After merge
- Point nudge hrefs through `/go/?src=…` (I'll follow up on aw-webui#914 to route the in-app nudge through it — held until this merges so it doesn't 404).
- Replace the `buy.stripe.com/PLACEHOLDER_*` destination URLs once the Stripe Payment Links exist.
- Optionally register `src`/`dest` as GA4 custom dimensions to make them selectable in reports (events record regardless).

Staged design + Cloudflare-Worker alternative + full src→destination table: `knowledge/strategic/aw-redirect/README.md` in the brain repo.