### PR TITLE
feat: add Subscribe CTA to homepage How to Contribute section

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -105,9 +105,13 @@ div.container
         | ActivityWatch is built entirely by volunteers and we need help from people (like you!) to keep the project going.
         | If you're interested in contributing, check out the #[a(href="https://github.com/ActivityWatch/activitywatch/blob/master/CONTRIBUTING.md") contributing guide].
 
+      h4 Support the project
+      p
+        | ActivityWatch Pro subscriptions fund ongoing development and keep the project independent. If ActivityWatch is useful to you, #[a(href="/subscribe/") subscribe] — plans start at $5/month.
+
       h4 Donate
       p
-        | If ActivityWatch has helped you in any way, and you don't have the means or time to contribute, please consider #[a(href="/donate/") donating].
+        | Prefer a one-time contribution? See the #[a(href="/donate/") donate page] for one-time payments, GitHub Sponsors, Open Collective, and more.
 
       h4 Spread the word
       p


### PR DESCRIPTION
## Summary

- Adds a **"Support the project"** h4 under "How to Contribute" pointing to `/subscribe/` (AW Pro subscriptions), since that page launched 2026-07-22 with Stripe Payment Links but wasn't linked from the homepage body
- Reframes the existing **"Donate"** h4 toward one-time/alternative payment options, so each has a clear distinct role
- The "Support" nav link already exists; this makes the subscribe option discoverable from the page body too

## Context

AW Pro subscriptions went live 2026-07-22 via PR #64. All 5 Stripe checkout URLs are verified live (all return HTTP 200). The `/subscribe/` page, `/go/` redirect, and `/thanks/` page are all live. The only gap in discoverability was the homepage body — the navbar "Support" link exists but isn't visible on mobile without expanding the menu, and a reader scrolling through the page content has no subscription CTA.

## Test plan

- [ ] Build site locally: `bundle exec jekyll serve`
- [ ] Visit homepage → scroll to "How to Contribute" → confirm "Support the project" and updated "Donate" sections render correctly
- [ ] Click "subscribe" link → verify it goes to `/subscribe/`